### PR TITLE
Fixed rebuilding VirgilCrypto

### DIFF
--- a/Scripts/move_framework.sh
+++ b/Scripts/move_framework.sh
@@ -15,16 +15,16 @@ rm -rf "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
 
 case "${SWIFT_PLATFORM_TARGET_PREFIX}" in
     "ios")
-        cp -R "VSCCrypto/PrebuiltFramework/iOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
+        cp -R -p "VSCCrypto/PrebuiltFramework/iOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
     ;;
     "macosx")
-        cp -R "VSCCrypto/PrebuiltFramework/macOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
+        cp -R -p "VSCCrypto/PrebuiltFramework/macOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
     ;;
     "tvos")
-        cp -R "VSCCrypto/PrebuiltFramework/tvOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
+        cp -R -p "VSCCrypto/PrebuiltFramework/tvOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
     ;;
     "watchos")
-        cp -R "VSCCrypto/PrebuiltFramework/watchOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
+        cp -R -p "VSCCrypto/PrebuiltFramework/watchOS/${PRODUCT_NAME}.framework" "${BUILT_PRODUCTS_DIR}/${PRODUCT_NAME}.framework"
     ;;
 esac
 

--- a/VirgilCryptoApiImpl/Source/VirgilCrypto+KeyManagement.swift
+++ b/VirgilCryptoApiImpl/Source/VirgilCrypto+KeyManagement.swift
@@ -101,7 +101,7 @@ extension VirgilCrypto {
         return privateKey.rawKey
     }
 
-    /// Expots encrypted using password private key
+    /// Exports encrypted using password private key
     ///
     /// - Parameters:
     ///   - privateKey: PrivateKey to export
@@ -139,7 +139,7 @@ extension VirgilCrypto {
         return publicKey.rawKey
     }
 
-    /// Import public key from DER or PEM format
+    /// Imports public key from DER or PEM format
     ///
     /// - Parameter data: Public key in DER or PEM format
     /// - Returns: Imported Public Key

--- a/VirgilCryptoApiImpl/Source/VirgilCrypto.swift
+++ b/VirgilCryptoApiImpl/Source/VirgilCrypto.swift
@@ -62,7 +62,7 @@ import VirgilCryptoAPI
     ///   - defaultKeyType: Key type used to generate keys by default
     ///   - useSHA256Fingerprints: Use old algorithm to generate key fingerprints
     ///                            Current algorithm: first 8 bytes of SHA512 of public key in DER format
-    ///                            Old algorithml SHA256 of public key in DER format
+    ///                            Old algorithm SHA256 of public key in DER format
     ///                            NOTE: Use SHA256 fingerprint only if you need to work with encrypted data,
     ///                                  that was encrypted using those fingerprint. (e.g. version 2 of this library)
     @objc public init(defaultKeyType: VSCKeyType = .FAST_EC_ED25519, useSHA256Fingerprints: Bool = false) {


### PR DESCRIPTION
Added *-p* option to copy command in *move_frameworks.sh* script to keep hash value of copied framework unchanged after several executions of script.