### PR TITLE
Bump virgil-crypto-c to 0.19.0-rc.12; rename Round5 → ML-KEM-768

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,14 +1,14 @@
 {
-  "pins" : [
+  "pins": [
     {
-      "identity" : "virgil-crypto-c",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-c.git",
-      "state" : {
-        "revision" : "3f2c23f1f96832ee4e7c5639b44f22b86262bd3c",
-        "version" : "0.19.0-rc.11"
+      "identity": "virgil-crypto-c",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-c.git",
+      "state": {
+        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
+        "version": "0.19.0-rc.12"
       }
     }
   ],
-  "version" : 2
+  "version": 2
 }

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.11")
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.12")
     ],
 
     targets: [

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Virgil Security Objective-C/Swift Crypto Library uses Swift wrapper [Virgil Secu
 * Encryption/Decryption of data and streams
 * Generation/Verification of digital signatures
 * Double Ratchet algorithm support
-* **Post-quantum algorithms support**: [Round5](https://round5.org/) (encryption) and [Falcon](https://falcon-sign.info/) (signature) 
+* **Post-quantum algorithms support**: [ML-KEM-768](https://csrc.nist.gov/pubs/fips/203/final) (encryption) and [Falcon](https://falcon-sign.info/) (signature)
 * Crypto for using [Virgil Core SDK](https://github.com/VirgilSecurity/virgil-sdk-x)
 
 ## Installation

--- a/Source/KeyPairType+Convert.swift
+++ b/Source/KeyPairType+Convert.swift
@@ -61,7 +61,7 @@ extension KeyPairType {
                     && cipherHybrid.secondKeyAlgInfo().algId() == .mlKem768
                     && signerHybrid.firstKeyAlgInfo().algId() == .ed25519
                     && signerHybrid.secondKeyAlgInfo().algId() == .falcon {
-                    self = .curve25519Round5Ed25519Falcon
+                    self = .curve25519MlKem768Ed25519Falcon
                 } else {
                     throw VirgilCryptoError.unknownCompoundKey
                 }
@@ -81,7 +81,7 @@ extension KeyPairType {
 
             if hybridInfo.firstKeyAlgInfo().algId() == .curve25519
                 && hybridInfo.secondKeyAlgInfo().algId() == .mlKem768 {
-                self = .curve25519Round5
+                self = .curve25519MlKem768
             } else {
                 throw VirgilCryptoError.unknownCompoundKey
             }
@@ -116,14 +116,14 @@ extension KeyPairType {
             return .secp256r1
         case .rsa2048, .rsa4096, .rsa8192:
             return .rsa
-        case .curve25519Round5Ed25519Falcon, .curve25519Ed25519, .curve25519Round5:
+        case .curve25519MlKem768Ed25519Falcon, .curve25519Ed25519, .curve25519MlKem768:
             throw VirgilCryptoError.compundKeyShouldBeGeneratedDirectly
         }
     }
 
     internal var isHybrid: Bool {
         switch self {
-        case .curve25519Ed25519, .curve25519Round5Ed25519Falcon, .curve25519Round5:
+        case .curve25519Ed25519, .curve25519MlKem768Ed25519Falcon, .curve25519MlKem768:
             return true
         case .curve25519, .ed25519, .rsa2048, .rsa4096, .rsa8192, .secp256r1:
             return false
@@ -132,20 +132,20 @@ extension KeyPairType {
 
     internal var isCompound: Bool {
         switch self {
-        case .curve25519Ed25519, .curve25519Round5Ed25519Falcon:
+        case .curve25519Ed25519, .curve25519MlKem768Ed25519Falcon:
             return true
-        case .curve25519, .ed25519, .rsa2048, .rsa4096, .rsa8192, .secp256r1, .curve25519Round5:
+        case .curve25519, .ed25519, .rsa2048, .rsa4096, .rsa8192, .secp256r1, .curve25519MlKem768:
             return false
         }
     }
 
     internal func getSignerKeysAlgIds() throws -> (first: AlgId, second: AlgId) {
         switch self {
-        case .curve25519Round5:
+        case .curve25519MlKem768:
             return (.none, .none)
         case .curve25519Ed25519:
             return (.ed25519, .none)
-        case .curve25519Round5Ed25519Falcon:
+        case .curve25519MlKem768Ed25519Falcon:
             return (.ed25519, .falcon)
         case .curve25519, .ed25519, .rsa2048, .rsa4096, .rsa8192, .secp256r1:
             throw VirgilCryptoError.keyIsNotCompound
@@ -156,7 +156,7 @@ extension KeyPairType {
         switch self {
         case .curve25519Ed25519:
             return (.curve25519, .none)
-        case .curve25519Round5Ed25519Falcon, .curve25519Round5:
+        case .curve25519MlKem768Ed25519Falcon, .curve25519MlKem768:
             return (.curve25519, .mlKem768)
         case .curve25519, .ed25519, .rsa2048, .rsa4096, .rsa8192, .secp256r1:
             throw VirgilCryptoError.keyIsNotCompound

--- a/Source/KeyPairType+String.swift
+++ b/Source/KeyPairType+String.swift
@@ -47,8 +47,8 @@ extension KeyPairType {
         case rsa2048
         case rsa4096
         case rsa8192
-        case curve25519Round5
-        case curve25519Round5Ed25519Falcon
+        case curve25519MlKem768
+        case curve25519MlKem768Ed25519Falcon
         case curve25519Ed25519
     }
 
@@ -69,10 +69,10 @@ extension KeyPairType {
             self = .rsa4096
         case KeyPairTypeStr.rsa8192.rawValue:
             self = .rsa8192
-        case KeyPairTypeStr.curve25519Round5.rawValue:
-            self = .curve25519Round5
-        case KeyPairTypeStr.curve25519Round5Ed25519Falcon.rawValue:
-            self = .curve25519Round5Ed25519Falcon
+        case KeyPairTypeStr.curve25519MlKem768.rawValue:
+            self = .curve25519MlKem768
+        case KeyPairTypeStr.curve25519MlKem768Ed25519Falcon.rawValue:
+            self = .curve25519MlKem768Ed25519Falcon
         case KeyPairTypeStr.curve25519Ed25519.rawValue:
             self = .curve25519Ed25519
 
@@ -96,10 +96,10 @@ extension KeyPairType {
             return KeyPairTypeStr.rsa4096.rawValue
         case .rsa8192:
             return KeyPairTypeStr.rsa8192.rawValue
-        case .curve25519Round5:
-            return KeyPairTypeStr.curve25519Round5.rawValue
-        case .curve25519Round5Ed25519Falcon:
-            return KeyPairTypeStr.curve25519Round5Ed25519Falcon.rawValue
+        case .curve25519MlKem768:
+            return KeyPairTypeStr.curve25519MlKem768.rawValue
+        case .curve25519MlKem768Ed25519Falcon:
+            return KeyPairTypeStr.curve25519MlKem768Ed25519Falcon.rawValue
         case .curve25519Ed25519:
             return KeyPairTypeStr.curve25519Ed25519.rawValue
         }

--- a/Source/KeyPairType.swift
+++ b/Source/KeyPairType.swift
@@ -44,8 +44,8 @@ import Foundation
 /// - rsa2048: rsa with 2048 length
 /// - rsa4096: rsa with 4096 length
 /// - rsa8192: rsa with 8192 length
-/// - curve25519Round5: curve25519 and round5
-/// - curve25519Round5Ed25519Falcon: ed25519 and falcon used for signing, curve25519 and round used for hybrid ECIES
+/// - curve25519MlKem768: curve25519 (DH) + ML-KEM-768 (PQC KEM)
+/// - curve25519MlKem768Ed25519Falcon: curve25519 + ML-KEM-768 (cipher), ed25519 + Falcon (signer)
 /// - curve25519Ed25519: ed25519 used for signing, curve25519 used for ECIES
 @objc(VSMKeyPairType) public enum KeyPairType: Int {
     case ed25519
@@ -54,7 +54,7 @@ import Foundation
     case rsa2048
     case rsa4096
     case rsa8192
-    case curve25519Round5
-    case curve25519Round5Ed25519Falcon
+    case curve25519MlKem768
+    case curve25519MlKem768Ed25519Falcon
     case curve25519Ed25519
 }

--- a/Tests/VSM001_CryptoTests.swift
+++ b/Tests/VSM001_CryptoTests.swift
@@ -53,8 +53,8 @@ class VSM001_CryptoTests: XCTestCase {
         XCTAssert(keyPair.privateKey.identifier == keyPair.publicKey.identifier)
     }
     
-    private static let allKeyTypes: [KeyPairType] = [.curve25519, .ed25519, .secp256r1, .rsa2048, .curve25519Round5Ed25519Falcon, .curve25519Ed25519, .curve25519Round5]
-    private static let signingKeyTypes: [KeyPairType] = [.ed25519, .secp256r1, .rsa2048, .curve25519Round5Ed25519Falcon, .curve25519Ed25519]
+    private static let allKeyTypes: [KeyPairType] = [.curve25519, .ed25519, .secp256r1, .rsa2048, .curve25519MlKem768Ed25519Falcon, .curve25519Ed25519, .curve25519MlKem768]
+    private static let signingKeyTypes: [KeyPairType] = [.ed25519, .secp256r1, .rsa2048, .curve25519MlKem768Ed25519Falcon, .curve25519Ed25519]
 
     func test01__key_generation__generate_one_key__should_succeed() {
         do {

--- a/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,14 +1,14 @@
 {
-  "pins" : [
+  "pins": [
     {
-      "identity" : "virgil-crypto-c",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/VirgilSecurity/virgil-crypto-c",
-      "state" : {
-        "revision" : "3f2c23f1f96832ee4e7c5639b44f22b86262bd3c",
-        "version" : "0.19.0-rc.11"
+      "identity": "virgil-crypto-c",
+      "kind": "remoteSourceControl",
+      "location": "https://github.com/VirgilSecurity/virgil-crypto-c",
+      "state": {
+        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
+        "version": "0.19.0-rc.12"
       }
     }
   ],
-  "version" : 2
+  "version": 2
 }


### PR DESCRIPTION
## Summary

- Bump `virgil-crypto-c` dependency from `0.19.0-rc.11` to `0.19.0-rc.12` (contains ratchet XXDH fixes)
- Rename `KeyPairType` enum cases to reflect the actual algorithm now that Round5 has been replaced:
  - `curve25519Round5` → `curve25519MlKem768`
  - `curve25519Round5Ed25519Falcon` → `curve25519MlKem768Ed25519Falcon`
- Update doc comments and README: Round5 → ML-KEM-768

## Test plan

- [ ] All CI jobs pass (SPM build, Xcode tests iOS/tvOS/watchOS/macOS, Swiftlint)