### PR TITLE
Bump virgil-crypto-c to 0.19.0-rc.13

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state": {
-        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
-        "version": "0.19.0-rc.12"
+        "revision": "14942f289394c6819b0547ee20e5dfc26217021f",
+        "version": "0.19.0-rc.13"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.12")
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.13")
     ],
 
     targets: [

--- a/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/VirgilSecurity/virgil-crypto-c",
       "state": {
-        "revision": "e386be51ec32aed0391a26925e657b25b2bdbe50",
-        "version": "0.19.0-rc.12"
+        "revision": "14942f289394c6819b0547ee20e5dfc26217021f",
+        "version": "0.19.0-rc.13"
       }
     }
   ],


### PR DESCRIPTION
Bumps virgil-crypto-c from 0.19.0-rc.12 to 0.19.0-rc.13. Fixes macOS arm64 assertion crash in vscr_ratchet_pb_utils.c.