### PR TITLE
Bump virgil-crypto-c to 0.19.0-rc.14

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/VirgilSecurity/virgil-crypto-c.git",
       "state": {
-        "revision": "14942f289394c6819b0547ee20e5dfc26217021f",
-        "version": "0.19.0-rc.13"
+        "revision": "f6a271fd63f63d7e5993ad65ff7b5aad02540cde",
+        "version": "0.19.0-rc.14"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     ],
 
     dependencies: [
-        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.13")
+        .package(url: "https://github.com/VirgilSecurity/virgil-crypto-c.git", exact: "0.19.0-rc.14")
     ],
 
     targets: [

--- a/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/VirgilCrypto.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind": "remoteSourceControl",
       "location": "https://github.com/VirgilSecurity/virgil-crypto-c",
       "state": {
-        "revision": "14942f289394c6819b0547ee20e5dfc26217021f",
-        "version": "0.19.0-rc.13"
+        "revision": "f6a271fd63f63d7e5993ad65ff7b5aad02540cde",
+        "version": "0.19.0-rc.14"
       }
     }
   ],


### PR DESCRIPTION
Fixes macOS arm64 assertion crash (vscr_ratchet_pb_utils.c:267) — sender-plain/receiver-PQC case where IK_r has no ML-KEM component (encapsulated_key1 absent).